### PR TITLE
Python 3.6, ElasticSearch 6.0, and snapshotid support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,106 @@
 Import your AWS Config Snapshots into ElasticSearch
 ===================================================
+
 ### Author: Vladimir Budilov
-* [LinkedIn](https://www.linkedin.com/in/vbudilov/)
-* [Medium](https://medium.com/@budilov)
+
+-   [LinkedIn](https://www.linkedin.com/in/vbudilov/)
+
+-   [Medium](https://medium.com/@budilov)
 
 ### What problem does this app solve?
-You have a lot of resources in your AWS account and want to search and visualize them. For example, you'd like to know your EC2 Avaiability Zone distribution or how many EC2 instances are uzing a particular Security Group
+
+You have a lot of resources in your AWS account and want to search and visualize
+them. For example, you'd like to know your EC2 Avaiability Zone distribution or
+how many EC2 instances are uzing a particular Security Group
 
 ### What does this app do?
-It will ingest your AWS Config Snapshots into ElasticSearch for further analysis with Kibana. Please
-refer to [this blog post](https://aws.amazon.com/blogs/developer/how-to-analyze-aws-config-snapshots-with-elasticsearch-and-kibana/)
+
+It will ingest your AWS Config Snapshots into ElasticSearch for further analysis
+with Kibana. Please refer to [this blog
+post](https://aws.amazon.com/blogs/developer/how-to-analyze-aws-config-snapshots-with-elasticsearch-and-kibana/)
 for a more in-depth explanation of this solution.
 
-
 ### Getting the code
-```
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 git clone --depth 1 git@github.com:awslabs/aws-config-to-elasticsearch.git
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ### The code
+
 #### Prerequisites
-* Python 2.7
-* An ELK stack, up and running
-* Install the required packages. The requirements.txt file is included with this repo.
-```
+
+-   AWS Config configured in one or more regions
+
+-   Python 2.7 or 3.6
+
+-   An ELK stack, up and running
+
+-   Install the required packages. The requirements.txt file is included with
+    this repo.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pip install -r ./requirements.txt
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #### The command
-```bash
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 ./esingest.py
-usage: esingest.py [-h] [--region REGION] --destination DESTINATION [--verbose]
+usage: esingest.py [-h] [--region REGION [--snapshotid]] --destination DESTINATION [--verbose]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-```
+1.  Let's say that you have your ElasticSearch node running on localhost:9200
+    and you want to import only your us-east-1 snapshot, then you'd run the
+    following command:
 
-1. Let's say that you have your ElasticSearch node running on localhost:9200 and you want to import only your us-east-1 snapshot, then you'd run the following command:
-```bash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 ./esingest.py -d localhost:9200 -r us-east-1
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-2. If you want to import Snapshots from all of your AWS Config-enabled regions, run the command without the '-r' parameter:
-```bash
+1.  If you want to import Snapshots from all of your AWS Config-enabled regions,
+    run the command without the '-r' parameter:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 ./esingest.py -d localhost:9200
-```
-3. To run the command in verbose mode, use the -v parameter
-```bash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1.  To run the command in verbose mode, use the -v parameter
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 ./esingest.py -v -d localhost:9200 -r us-east-1
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1.  To run the command against an existing snapshot, use the -s parameter with
+    the -r parameter
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./esingest.py --region us-east-1 --snapshotid 43499c03-c911-4ace-94f8-f36f38f1ff2d --verbose -d localhost:9200
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ### Cleanup
 
-####DON'T RUN THESE COMMANDS IF YOU DON'T WANT TO LOSE EVERYTHING IN YOUR ELASTICSEARCH NODE!
+\#\#\#\#DON'T RUN THESE COMMANDS IF YOU DON'T WANT TO LOSE EVERYTHING IN YOUR
+ELASTICSEARCH NODE!
 
-#####_THIS COMMAND WILL ERASE EVERYTHING FROM YOUR ES NODE --- BE CAREFUL BEFORE RUNNING_
-```bash
+\#\#\#\#\#*THIS COMMAND WILL ERASE EVERYTHING FROM YOUR ES NODE --- BE CAREFUL
+BEFORE RUNNING*
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 curl -XDELETE localhost:9200/_all
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to avoid losing all of your data, you can just iterate over all of your indexes and delete them that way. The below command will print out all of your indexes that contain 'aws::'. You can then run a DELETE on just these indexes.
-```bash
+In order to avoid losing all of your data, you can just iterate over all of your
+indexes and delete them that way. The below command will print out all of your
+indexes that contain 'aws::'. You can then run a DELETE on just these indexes.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 curl 'localhost:9200/_cat/indices' | awk '{print $3}' | grep "aws::"
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Also delete the template which allows for creationg of a 'raw' string value alongside every 'analyzed' one
-```bash
+Also delete the template which allows for creationg of a 'raw' string value
+alongside every 'analyzed' one
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ bash
 curl -XDELETE localhost:9200/_template/configservice
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/aws_config_to_es/elastic.py
+++ b/aws_config_to_es/elastic.py
@@ -27,6 +27,9 @@ class ElasticSearch(object):
             Returns the id of the newly inserted value or None
             if the added date is not there, then I'm adding it in
         """
+
+        headers = {'content-type': 'application/json'}
+
         if not isinstance(json_message, dict):
             json_message_dict = json.loads(json_message)
         else:
@@ -42,11 +45,11 @@ class ElasticSearch(object):
             response = requests.put(self.connections + "/" +
                                     index_name + "/" +
                                     doc_type + "/" +
-                                    index_id, data=json_message)
+                                    index_id, data=json_message, headers=headers)
         else:
             response = requests.post(self.connections + "/" +
                                      index_name + "/" +
-                                     doc_type, data=json_message)
+                                     doc_type, data=json_message, headers=headers)
 
         self.log.info(
             "response: " + str(
@@ -68,6 +71,8 @@ class ElasticSearch(object):
         the data won't be tokenized, and therefore can be
         searched by the value itself
         """
+
+        headers = {'content-type': 'application/json'}
 
         payload = {
             "template": "*",
@@ -98,4 +103,4 @@ class ElasticSearch(object):
         }
         requests.put(
             self.connections + "/_template/configservice",
-            data=json.dumps(payload))
+            data=json.dumps(payload), headers=headers)


### PR DESCRIPTION
Tested with Python 3.6 and found no issues.
Added Content-Type header for ElasticSearch 6.0 compatibility (tested with 6.3)
Added a "snapshotid" parameter which allows the user to run against an existing snapshot, rather than call snapshot delivery (which can be throttled).

Note that most of the diff changes in README.md seem to be false positives from my editor. I did add some details on the changes.

-- miobrien@